### PR TITLE
Add php evaluation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk update && \
     apk add --no-cache \
     gcc \
     g++ \
+    php \
     python3 \
     rust \
     iptables \

--- a/eval.js
+++ b/eval.js
@@ -58,7 +58,7 @@ let langs = {
     command: "php",
     postfix: ".php",
     name: "PHP",
-    template: "{CODE}"
+    template: "<?php\n{CODE}\n?>"
   },
   c: {
     type: "compiler",

--- a/eval.js
+++ b/eval.js
@@ -53,6 +53,13 @@ let langs = {
     template: "{CODE}"
 
   },
+  php: {
+    type: "interpreter",
+    command: "php",
+    postfix: ".php",
+    name: "PHP",
+    template: "{CODE}"
+  },
   c: {
     type: "compiler",
     command: "gcc",
@@ -210,8 +217,8 @@ async function sendHelp(msg) {
     .setDescription('Use a codeblock with language of your choosing and code within, example:\n' +
       '\\\`\\\`\\\`cpp\nstd::cout << "hello world!";\n\\\`\\\`\\\`\n' +
       '\`\`\`cpp\nstd::cout << "hello world!";\`\`\`')
-    .addField('Supported languages', 'Javascript, Python, c, c++ and rust.\n' +
-      'js, py, c, c++/cpp and rs.')
+    .addField('Supported languages', 'Javascript, Python, PHP, c, c++ and rust.\n' +
+      'js, py, php, c, c++/cpp and rs.')
     .addField("Warning!", "Abuse of the system and intentionally breaking it will result in a blacklist")
     .setFooter("Collaborators: Dodo#1948 | Toast#1042")
     .setColor('#FAA61A')


### PR DESCRIPTION
Add php support to evaluator (default php version in alpine is currently php7)
![image](https://user-images.githubusercontent.com/44153531/134670442-589f38df-bef9-4514-836a-767356998e8e.png)
